### PR TITLE
Fixed bug when remoteService is not active

### DIFF
--- a/src/talkify-playlist.js
+++ b/src/talkify-playlist.js
@@ -310,7 +310,7 @@ talkify.playlist = function () {
 
         function playFromBeginning() {
             if (!talkify.config.remoteService.active) {
-                onComplete({ Culture: '', Language: -1 });
+                onComplete({ Cultures: [], Language: -1 });
 
                 return;
             }


### PR DESCRIPTION
When remoteService is set to false in the config options, the onComplete() method would be called with faulty parameters resulting in an error when playlist.play() was called.

Thanks for reviewing this minor fix.